### PR TITLE
Update css for "Remove linked page arrows" tweak

### DIFF
--- a/advanced/tweaks.md
+++ b/advanced/tweaks.md
@@ -221,13 +221,28 @@ repository.
 
 #### Remove Linked Page Arrows
 
-> Last updated: 2021-12-23
+> Last updated: 2022-02-10
 
 ![](https://user-images.githubusercontent.com/16874139/147217098-020034ab-a487-4456-bfea-f4df525cb9f5.png)
 
 ```css
-.pageLinkIndicator {
+/* To remove both linked page and linked database arrows */
+svg.pageLinkIndicator {
   display: none !important;
+}
+
+/* To remove only linked database arrows */
+.notion-collection_view-block svg.pageLinkIndicator {
+  display: none !important;
+}
+
+
+/* To remove only linked page arrows */
+svg.pageLinkIndicator {
+  display: none !important;
+}
+.notion-collection_view-block svg.pageLinkIndicator {
+  display: block !important;
 }
 ```
 

--- a/advanced/tweaks.md
+++ b/advanced/tweaks.md
@@ -219,25 +219,24 @@ repository.
 }
 ```
 
-#### Remove Linked Page Arrows
+#### Remove Link Arrows
 
 > Last updated: 2022-02-10
 
 ![](https://user-images.githubusercontent.com/16874139/147217098-020034ab-a487-4456-bfea-f4df525cb9f5.png)
 
 ```css
-/* To remove both linked page and linked database arrows */
+/* remove all link arrows */
 svg.pageLinkIndicator {
   display: none !important;
 }
 
-/* To remove only linked database arrows */
+/* remove linked database arrows only */
 .notion-collection_view-block svg.pageLinkIndicator {
   display: none !important;
 }
 
-
-/* To remove only linked page arrows */
+/* remove linked page arrows only */
 svg.pageLinkIndicator {
   display: none !important;
 }


### PR DESCRIPTION
This PR modifies the "Remove linked page arrows" tweak, adding css to remove arrows only on linked pages or linked databases, as requested to me by a user via email.

Cheers.
